### PR TITLE
(select-region-active-mode 1) is called only when set-mark-command is called.

### DIFF
--- a/selected.el
+++ b/selected.el
@@ -66,8 +66,9 @@
           (assq-delete-all 'selected-region-active-mode minor-mode-overriding-map-alist))))
 
 (defun selected--on ()
-  "Enable `selected-region-active-mode'."
-  (selected-region-active-mode 1))
+  (when (eq this-command 'set-mark-command)
+    "Enable `selected-region-active-mode'."
+    (selected-region-active-mode 1)))
 
 (defun selected-off ()
   "Disable bindings in `selected-keymap' temporarily."


### PR DESCRIPTION
Selected is implemented to register `selected--on` in `activate-mark-hook` so that `selected--on` is called when `activate-mark` is called.

However, there are two use cases where `activate-mark` is called:

- The first is when the user hits `set-mark-command`.
- The second is when the program calls `activate-mark`.

As an example of the latter, activate-mark is called when you type an opening brace(c-electric-brace).

The former case should enable `selected-region-active-mode`, while the latter case should not enable `selected-region-active-mode`.
