### PR TITLE
Silence compiler warnings

### DIFF
--- a/selected.el
+++ b/selected.el
@@ -30,6 +30,13 @@
 ;; want selected-minor-mode in all buffers.
 
 ;;; Code:
+
+(defgroup selected nil
+  "Keymap for when the region is active."
+  :prefix "selected-"
+  :group 'convenience
+  :link '(url-link "https://github.com/Kungsgeten/selected.el"))
+
 (defcustom selected-ignore-modes
   nil
   "List of major modes for which selected will not be turned on."
@@ -37,13 +44,15 @@
   :group 'selected)
 
 (defvar selected-keymap (make-sparse-keymap)
-  "Keymap for `selected-minor-mode'.  Add keys here that should be active when region is active.")
+  "Keymap for `selected-minor-mode'.
+Add keys here that should be active when region is active.")
 
 (defvar selected-minor-mode-override nil
   "Put keys in `selected-keymap' into `minor-mode-overriding-map-alist'?")
 
 (define-minor-mode selected-region-active-mode
-  "Meant to activate when region becomes active.  Not intended for the user.  Use `selected-minor-mode'."
+  "Meant to activate when region becomes active.
+Not intended for the user.  Use `selected-minor-mode'."
   :keymap selected-keymap
   (if selected-region-active-mode
       (let* ((major-selected-map

--- a/selected.el
+++ b/selected.el
@@ -4,7 +4,7 @@
 ;; MIT License
 
 ;; Author: Erik Sjöstrand
-;; URL: http://github.com/Kungsgeten/selected.el
+;; URL: https://github.com/Kungsgeten/selected.el
 ;; Version: 1.02
 ;; Keywords: convenience
 ;; Package-Requires: ()

--- a/selected.el
+++ b/selected.el
@@ -35,7 +35,7 @@
   "Keymap for when the region is active."
   :prefix "selected-"
   :group 'convenience
-  :link '(url-link "https://github.com/Kungsgeten/selected.el"))
+  :link '(url-link :tag "Website" "https://github.com/Kungsgeten/selected.el"))
 
 (defcustom selected-ignore-modes
   nil


### PR DESCRIPTION
Hey!

I'm just about to test out `selected.el` (it's been on my radar for a little while).

When I installed it either the byte compiler or the native compiler showed me a bunch of warnings. Here are fixes for those. They *should* be purely cosmetic, but since I haven't tested `selected.el` out yet I can't confirm that 100%. :)